### PR TITLE
Fix bug with classname resolution for availability

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -832,7 +832,7 @@ class format_twocol extends core_courseformat\base {
             $modinfo = $this->get_modinfo();
             $section = $modinfo->get_section_info($section->section);
         }
-        $elementclass = $this->get_output_classname('section_format\\availability');
+        $elementclass = $this->get_output_classname('content\\section\\availability');
         $availability = new $elementclass($this, $section);
 
         $rv['section_availability'] = $renderer->render($availability);


### PR DESCRIPTION
Clicking 'Hide section" in the section menu would lead to a stacktrace.

Before: 
![image](https://github.com/catalyst/moodle-format_twocol/assets/21162968/38e6d15d-2967-4949-acd9-f74a766a653a)

After: 
![image](https://github.com/catalyst/moodle-format_twocol/assets/21162968/1a1b048a-d1ac-4c1c-8476-9fd9146a4713)
