### PR TITLE
Add section controls to topic view

### DIFF
--- a/classes/output/courseformat/content.php
+++ b/classes/output/courseformat/content.php
@@ -330,6 +330,12 @@ class content extends content_base {
             $templatecontext->sectionimage = $this->get_course_image_or_pattern($course, $output, $imagenum);
         }
 
+        if ($format->show_editor()) {
+            $controlmenuclass = $format->get_output_classname('content\\section\\controlmenu');
+            $controlmenu = new $controlmenuclass($format, $thissection);
+            $templatecontext->controlmenu = $controlmenu->export_for_template($output);
+        }
+
         return $templatecontext;
     }
 

--- a/styles.css
+++ b/styles.css
@@ -368,3 +368,11 @@
         width: auto;
     }
 }
+
+.twocol .controlmenu-coursetopic {
+    margin: 6px;
+    display: flex;
+    flex-direction: row;
+    justify-content: end;
+    align-items: center;
+}

--- a/templates/course_topic.mustache
+++ b/templates/course_topic.mustache
@@ -27,6 +27,11 @@
 }}
 <div class="twocol">
     <div class="single-section">
+        {{#controlmenu}}
+            <div class="controlmenu-coursetopic">
+                {{> core_courseformat/local/content/section/controlmenu }}
+            </div>
+        {{/controlmenu}}
         <div class="section-navigation navigationtitle course-img course-img-{{{sectionimageformat}}}"
             {{#sectionimage}}style='background-image: url("{{{sectionimage}}}"), linear-gradient({{{headerbackcolor}}}, {{{headerbackcolor}}});' {{/sectionimage}}
             {{^sectionimage}}style='background-color: {{{headerbackcolor}}};'{{/sectionimage}}


### PR DESCRIPTION
 M4.0+ reworked the ways that section controls work. Since twocol does some logic around main course page vs single course page, the section controls dropdown doesn't get added (since its added in the base, but the base is skipped in favor of a custom class)

Based off the existing code for `print_course_summary()` (the main view page)
https://github.com/catalyst/moodle-format_twocol/blob/f546bea6e2ccf4ce8d34884023c0798d5e97c016/classes/output/courseformat/content.php#L166-L170

I copied this to the `print_course_topic()` (when viewing a single topic AKA section)
https://github.com/catalyst/moodle-format_twocol/blob/f546bea6e2ccf4ce8d34884023c0798d5e97c016/classes/output/courseformat/content.php#L333-L337

I then just added some extra styling to get it to sit right.

## Screenshots:
Boost:
![2023-11-14_12-26](https://github.com/catalyst/moodle-format_twocol/assets/17095477/d041c86d-43be-41ef-83d3-39cc5b4d9304)

BAZ:
![2023-11-14_12-22](https://github.com/catalyst/moodle-format_twocol/assets/17095477/17759966-6700-45a3-a4d5-7f49ef8afc11)

Catawesome:
![2023-11-14_12-44](https://github.com/catalyst/moodle-format_twocol/assets/17095477/42ecf054-f7eb-4ff5-85b5-2d60238d2e19)

