### PR TITLE
[#58] - Updated completion stats item styling

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -350,8 +350,8 @@
         width: 30%;
         display: flex;
         flex-wrap: nowrap;
+        flex-direction: column;
         align-items: center;
-        justify-content: center;
     }
 
     #page-course-view-twocol .completion-stats .completion-stats-item .completion-stats-title {

--- a/version.php
+++ b/version.php
@@ -25,8 +25,8 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'format_twocol';
-$plugin->release = '2025072301';
-$plugin->version = 2025072301;
+$plugin->release = '2025072302';
+$plugin->version = 2025072302;
 $plugin->requires = 2024042200;
 $plugin->maturity = MATURITY_STABLE;
 $plugin->supported = [404, 405];


### PR DESCRIPTION
The flex column layout change also affects two column layouts without blocks.  

| Old | New |
|--------|--------|
| <img width="2874" height="1072" alt="Screenshot from 2026-05-26 15-08-24" src="https://github.com/user-attachments/assets/379d99e5-ae37-4de5-aef4-25569a417bcf" /> | <img width="2558" height="1062" alt="Screenshot from 2026-05-26 16-23-19" src="https://github.com/user-attachments/assets/16850303-0b42-48a4-ab04-f9f5a5def7db" /> | 

Fixes #58