### PR TITLE
Add section info data attributes for section0 template

### DIFF
--- a/classes/output/courseformat/content.php
+++ b/classes/output/courseformat/content.php
@@ -263,6 +263,7 @@ class content extends content_base {
         if (!empty($courseformatoptions['reversedisplay'])) {
             $templatecontext->reversedisplay = 1;
         }
+        $templatecontext->sectionid = $thissection->id;
         return $templatecontext;
     }
 

--- a/templates/course_summary.mustache
+++ b/templates/course_summary.mustache
@@ -130,7 +130,7 @@
 
           <h3>{{resourcesheading}}</h3>
           <ul class="twocol">
-           <li id="section-0" class="section main clearfix" aria-label="overview">
+           <li id="section-0" class="section main clearfix" aria-label="overview" data-for="section" data-id="{{sectionid}}">
                 <span class="hidden sectionname">overview</span>
                 <div class = "content">
                     {{#mods}}

--- a/version.php
+++ b/version.php
@@ -25,8 +25,8 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'format_twocol';
-$plugin->release = '2025072302';
-$plugin->version = 2025072302;
+$plugin->release = '2025072303';
+$plugin->version = 2025072303;
 $plugin->requires = 2024042200;
 $plugin->maturity = MATURITY_STABLE;
 $plugin->supported = [404, 405];


### PR DESCRIPTION
Some plugin Javascript relies on sections having properly defined data-for tags and data-id fields set, if they are a section header. Given that this is an editable chunk when in edit mode, these attributes should be set.

Initial issue noticed with block_sharing_cart:

https://github.com/praxisdigital/moodle-block_sharing_cart/blob/MOODLE_52_STABLE/amd/src/app/block/course/element.js#L176