### PR TITLE
Decreased completion stats number font size

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -326,7 +326,7 @@
 }
 
 #page-course-view-twocol .completion-stats .completion-stats-item .completion-stats-number {
-    font-size: 300%;
+    font-size: 200%;
     font-weight: 700;
     padding-right: 0.5rem;
 }
@@ -362,7 +362,7 @@
         line-height: 1rem;
     }
     #page-course-view-twocol .completion-stats .completion-stats-item .completion-stats-number {
-        font-size: 300%;
+        font-size: 200%;
         font-weight: 700;
         padding-right: 0.5rem;
         width: auto;

--- a/version.php
+++ b/version.php
@@ -25,8 +25,8 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'format_twocol';
-$plugin->release = '2025072303';
-$plugin->version = 2025072303;
+$plugin->release = '2025072304';
+$plugin->version = 2025072304;
 $plugin->requires = 2024042200;
 $plugin->maturity = MATURITY_STABLE;
 $plugin->supported = [404, 405];


### PR DESCRIPTION
Dropped to `200%` for desktop & mobile, fixes large numbers overlapping

| 300% Desktop | 200% Desktop |
|--------|--------|
| <img width="836" height="768" alt="completion-stats-300-p" src="https://github.com/user-attachments/assets/948e1b55-6166-446f-a5f8-e0d010960345" /> | <img width="822" height="776" alt="completion-stats-200-p" src="https://github.com/user-attachments/assets/426229ae-27da-4e9b-8b15-7a3922d2c9e6" /> |

| 300% Mobile | 200% Mobile |
|--------|--------|
| <img width="1782" height="856" alt="completion-stats-number-mob-300-p" src="https://github.com/user-attachments/assets/5384354e-bf9b-4b68-b425-2cb6c74e4270" /> | <img width="1810" height="834" alt="completion-stats-number-200-p" src="https://github.com/user-attachments/assets/07331137-cd5d-4ac4-a7c6-892a0127ff76" /> | 

