### PR TITLE
Moodle 501 stable issue63

### DIFF
--- a/classes/output/courseformat/content.php
+++ b/classes/output/courseformat/content.php
@@ -65,6 +65,8 @@ class content extends content_base {
 
         $format = $this->format;
         $displaysection = $format->get_sectionnum();
+        $data->sectionreturn = $displaysection ?: 'null';
+        $data->pagesectionid = $format->get_sectionid() ?? 'null';
         if (!empty($displaysection)) {
             $data->singlesectionpage = $this->print_single_section_page($output);
         } else {

--- a/classes/output/courseformat/content.php
+++ b/classes/output/courseformat/content.php
@@ -263,6 +263,7 @@ class content extends content_base {
         if (!empty($courseformatoptions['reversedisplay'])) {
             $templatecontext->reversedisplay = 1;
         }
+        $templatecontext->sectionid = $thissection->id;
         return $templatecontext;
     }
 

--- a/classes/output/courseformat/content.php
+++ b/classes/output/courseformat/content.php
@@ -342,6 +342,7 @@ class content extends content_base {
             $controlmenu = new $controlmenuclass($format, $thissection);
             $templatecontext->controlmenu = $controlmenu->export_for_template($output);
         }
+        $templatecontext->sectionid = $thissection->id;
 
         return $templatecontext;
     }

--- a/templates/course_summary.mustache
+++ b/templates/course_summary.mustache
@@ -130,7 +130,7 @@
 
           <h3>{{resourcesheading}}</h3>
           <ul class="twocol">
-           <li id="section-0" class="section main clearfix" aria-label="overview">
+           <li id="section-0" class="section main clearfix" aria-label="overview" data-for="section" data-id="{{sectionid}}">
                 <span class="hidden sectionname">overview</span>
                 <div class = "content">
                     {{#mods}}

--- a/templates/course_topic.mustache
+++ b/templates/course_topic.mustache
@@ -26,7 +26,7 @@
     }
 }}
 <div class="twocol">
-    <div class="single-section">
+    <div class="single-section" data-id="{{sectionid}}" data-for="section">
         {{#controlmenu}}
             <div class="controlmenu-coursetopic">
                 {{> core_courseformat/local/content/section/controlmenu }}

--- a/templates/local/content.mustache
+++ b/templates/local/content.mustache
@@ -33,6 +33,13 @@
 {{/coursesummary}}
 {{#singlesectionpage}}
     {{> format_twocol/course_topic }}
+    {{#js}}
+    require(['core_courseformat/local/content'], function(component) {
+        component.init(
+            '#page', {}, {{sectionreturn}}, {{#pagesectionid}}{{.}}{{/pagesectionid}}{{^pagesectionid}}null{{/pagesectionid}}
+        );
+    });
+    {{/js}}
 {{/singlesectionpage}}
 {{#multiplesectionpage}}
     {{> core_courseformat/local/content }}

--- a/version.php
+++ b/version.php
@@ -25,8 +25,8 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'format_twocol';
-$plugin->release = '2025072304';
-$plugin->version = 2025072304;
+$plugin->release = '2025072305';
+$plugin->version = 2025072305;
 $plugin->requires = 2024042200;
 $plugin->maturity = MATURITY_STABLE;
 $plugin->supported = [501, 501];

--- a/version.php
+++ b/version.php
@@ -25,8 +25,8 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'format_twocol';
-$plugin->release = '2025072302';
-$plugin->version = 2025072302;
+$plugin->release = '2025072303';
+$plugin->version = 2025072303;
 $plugin->requires = 2024042200;
 $plugin->maturity = MATURITY_STABLE;
 $plugin->supported = [501, 501];

--- a/version.php
+++ b/version.php
@@ -25,8 +25,8 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'format_twocol';
-$plugin->release = '2025072303';
-$plugin->version = 2025072303;
+$plugin->release = '2025072304';
+$plugin->version = 2025072304;
 $plugin->requires = 2024042200;
 $plugin->maturity = MATURITY_STABLE;
 $plugin->supported = [501, 501];


### PR DESCRIPTION
Closes #63

The upstream fix (cherry-picked from the 4.0.4 branch, commit e6ea52e)
added the required HTML attributes to the section element but did not
include the JS initialisation call.

On Moodle 5.1, the reactive course editor JS must be explicitly started
on single section pages. The core template that normally does this is
never rendered by the twocol format on that view, so drag and drop was
completely broken on ?section=N pages.

Export sectionreturn and pagesectionid from export_for_template() and
call component.init() in the single section page template block,
matching the same pattern used by the core courseformat content template.